### PR TITLE
Ensures mapred.task.timeout is formatted properly as an integer instead of a float

### DIFF
--- a/src/R/MapReduce/gwas.R
+++ b/src/R/MapReduce/gwas.R
@@ -200,7 +200,7 @@ gwas <- function(
     mapred=list(
       mapred.map.tasks=map.task.capacity(),
       mapred.reduce.tasks=mapred.reduce.tasks,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE,
       mapred.min.split.size=mapred.min.split.size
@@ -238,7 +238,7 @@ gwas <- function(
       mapred=list(
         mapred.map.tasks=map.task.capacity(),
         mapred.reduce.tasks=reduce.task.capacity(),
-        mapred.task.timeout=ONEMIN*minutes.until.timeout,
+        mapred.task.timeout=minutes(minutes.until.timeout),
         rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
         rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE,
         mapred.textoutputformat.usekey=F,

--- a/src/R/MapReduce/gwas_maxT_perm_adjust.R
+++ b/src/R/MapReduce/gwas_maxT_perm_adjust.R
@@ -61,7 +61,7 @@ gwas.maxT.perm.adjust <- function(
     shared=shared,
     mapred = list(
       mapred.reduce.tasks=0,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )

--- a/src/R/MapReduce/gwas_maxT_perm_findmax.R
+++ b/src/R/MapReduce/gwas_maxT_perm_findmax.R
@@ -73,7 +73,7 @@ gwas.maxT.perm.findmax <- function(
     partitioner=list(lims=1, type="integer"),
     mapred = list(
       mapred.reduce.tasks=reduce.task.capacity(),
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )
@@ -104,7 +104,7 @@ gwas.maxT.perm.findmax <- function(
     orderby="integer",
     mapred = list(
       mapred.reduce.tasks=1,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE,
       mapred.textoutputformat.usekey=T,

--- a/src/R/MapReduce/gwas_perm_broadcast.R
+++ b/src/R/MapReduce/gwas_perm_broadcast.R
@@ -74,7 +74,7 @@ gwas.perm.broadcast <- function(
     partitioner=list(lims=1, type="integer"),
     mapred = list(
       mapred.reduce.tasks=n.copies,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )

--- a/src/R/MapReduce/gwas_perm_collect.R
+++ b/src/R/MapReduce/gwas_perm_collect.R
@@ -37,7 +37,7 @@ gwas.perm.collect <- function(
     partitioner=list(lims=1, type="string"),
     mapred = list(
       mapred.reduce.tasks=reduce.task.capacity(),
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )

--- a/src/R/MapReduce/gwas_perm_report.R
+++ b/src/R/MapReduce/gwas_perm_report.R
@@ -80,7 +80,7 @@ gwas.perm.report <- function(
     orderby="numeric",
     mapred=list(
       mapred.reduce.tasks=1,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE,
       mapred.textoutputformat.usekey=F,

--- a/src/R/MapReduce/gwas_perm_run.R
+++ b/src/R/MapReduce/gwas_perm_run.R
@@ -168,7 +168,7 @@ gwas.perm.run <- function(
     partitioner=list(lims=1, type="string"),
     mapred = list(
       mapred.reduce.tasks=mapred.reduce.tasks,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )

--- a/src/R/MapReduce/gwas_sparse_report.R
+++ b/src/R/MapReduce/gwas_sparse_report.R
@@ -87,7 +87,7 @@ gwas.sparse.report <- function(
     orderby="character",
     mapred=list(
       mapred.reduce.tasks=mapred.reduce.tasks,
-      mapred.task.timeout=ONEMIN,
+      mapred.task.timeout=minutes(1),
       rhipe_map_buffsize=rhipe_map_buffsize,
       mapred.textoutputformat.usekey=F,
       mapred.field.separator="\t",

--- a/src/R/MapReduce/read_plink_tped.R
+++ b/src/R/MapReduce/read_plink_tped.R
@@ -80,7 +80,7 @@ read.plink.tped <- function(
     ofolder=ofolder,
     mapred=list(
       mapred.reduce.tasks=mapred.reduce.tasks,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )

--- a/src/R/MapReduce_helpers/example_user_code.R
+++ b/src/R/MapReduce_helpers/example_user_code.R
@@ -37,7 +37,7 @@ example.user.code <- function(ifolder, ofolder, user.code=NULL) {
     mapred=list(
       mapred.map.tasks=map.task.capacity(),
       mapred.reduce.tasks=reduce.task.capacity(),
-      mapred.task.timeout=ONEMIN
+      mapred.task.timeout=minutes(1)
     )
   )
   

--- a/src/R/MapReduce_helpers/filter_by_keys.R
+++ b/src/R/MapReduce_helpers/filter_by_keys.R
@@ -48,7 +48,7 @@ filter.by.keys <- function(
     mapred = list(
       mapred.map.tasks=map.task.capacity(),
       mapred.reduce.tasks=reduce.task.capacity(),
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE,
       mapred.min.split.size=mapred.min.split.size

--- a/src/R/MapReduce_helpers/identityMR.R
+++ b/src/R/MapReduce_helpers/identityMR.R
@@ -27,7 +27,7 @@ identityMR <- function(ifolder, ofolder, user.code=NULL) {
     mapred=list(
       mapred.map.tasks=map.task.capacity(),
       mapred.reduce.tasks=reduce.task.capacity(),
-      mapred.task.timeout=ONEMIN
+      mapred.task.timeout=minutes(1)
     )
   )
   

--- a/src/R/MapReduce_helpers/splits.R
+++ b/src/R/MapReduce_helpers/splits.R
@@ -24,7 +24,7 @@ splits <- function(
     ofolder=ofolder,
     mapred = list(
       mapred.reduce.tasks=n.splits,
-      mapred.task.timeout=ONEMIN*minutes.until.timeout,
+      mapred.task.timeout=minutes(minutes.until.timeout),
       rhipe_map_buffsize=RHIPE_MAP_BUFFSIZE,
       rhipe_reduce_buffsize=RHIPE_REDUCE_BUFFSIZE
     )

--- a/src/R/aaa.R
+++ b/src/R/aaa.R
@@ -20,6 +20,11 @@ ONEMIN = 60000  # ms
 RHIPE_MAP_BUFFSIZE    = 100  # number of records per batch **250MB Rhipe limit**
 RHIPE_REDUCE_BUFFSIZE = 100  # much safer than the default of 10,000 records
 
+# Minutes conversion function (as integers, not numerics)
+minutes <- function(m) {
+  as.integer(ONEMIN * m)
+}
+
 .onAttach <- function(libname, pkgname) {
   version <- read.dcf(file=system.file("DESCRIPTION", package=pkgname), fields="Version")
   packageStartupMessage(paste("\n", pkgname, version, "\n", "


### PR DESCRIPTION
We ran into an issue running BlueSNP where the job failed because mapred.task.timeout was getting set to "6e05" instead of "600000" because the default R behavior is to coerce numbers to doubles instead of integers and the TaskTracker was expecting a long value. This patch fixes the issue everywhere ONEMIN is referenced in the code.
